### PR TITLE
Make freegeos-font-liste compilable under linux.

### DIFF
--- a/fontlist.goc
+++ b/fontlist.goc
@@ -6,7 +6,7 @@
  */
 
 @include <stdapp.goh>
-#include <ansi\stdio.h>
+#include <Ansi/stdio.h>
 
 #define MAX_SAMPLE_LEN 512
 


### PR DESCRIPTION
Small modification so that this tool can also be built under Linux.